### PR TITLE
adjust version comparison to newer YAML::XS

### DIFF
--- a/lib/Debian/DEP12.pm
+++ b/lib/Debian/DEP12.pm
@@ -18,6 +18,7 @@ use Encode qw( decode );
 use Scalar::Util qw( blessed );
 use Text::BibTeX::Validate qw( validate_BibTeX );
 use YAML::XS;
+use version;
 
 # Preventing YAML::XS from doing undesired things:
 $YAML::XS::DumpCode = 0;
@@ -142,7 +143,7 @@ sub new
         return $class->new( { Reference => \@references } );
     } elsif( ref $what eq '' ) {
         # Text in YAML format
-        if( $YAML::XS::VERSION < 0.69 ) {
+        if( version->parse($YAML::XS::VERSION) < version->parse('0.69') ) {
             die 'YAML::XS < 0.69 is insecure' . "\n";
         }
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Debian-DEP12.
We thought you might be interested in it too.

    Description: adjust version comparison to newer YAML::XS
     YAML::XS changed its versioning scheme from 0.xx to v0.9xx.y,
     therefore numerical comparisons fail with
     Argument "v0.902.0" isn't numeric in numeric lt (<) at /usr/share/perl5/Debian/DEP12.pm line 127.
     which also breaks the testsuite.
     Use Perl's version() module instead, 
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-09-23
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libdebian-dep12-perl/raw/master/debian/patches/yaml-xs-version.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
